### PR TITLE
Adjust USPS signature mapping helper

### DIFF
--- a/app/external/usps.py
+++ b/app/external/usps.py
@@ -67,24 +67,32 @@ class USPSService:
             return data["access_token"]
     
 
-    def get_usps_signature_code(option: str, mailClass: str = "USPS_GROUND_ADVANTAGE") -> int:
+    def get_usps_signature_code(self, option: str, mailClass: str = "USPS_GROUND_ADVANTAGE") -> List[int]:
         """
-        Returns the USPS extra service code for a given signature option and shipping method.
+        Returns the USPS extra service codes for a given signature option and shipping method.
 
         Args:
             option (str): Custom signature option (e.g., 'direct', 'none', 'adult')
-            shipping_method (str): Shipping method (e.g., 'USPS_GROUND_ADVANTAGE', 'express')
+            mailClass (str): Shipping method (e.g., 'USPS_GROUND_ADVANTAGE', 'PRIORITY_MAIL')
 
         Returns:
-            int: USPS extra service code
+            List[int]: USPS extra service code list for the requested option.
 
         Raises:
             ValueError: If option or shipping method is invalid
         """
         try:
-            return _signature_options_map[mailClass][option]
+            codes = self._signature_options_map[mailClass][option]
         except KeyError:
             raise ValueError(f"Invalid combination: shipping_method='{mailClass}', option='{option}'")
+
+        logger.debug(
+            "Resolved USPS signature option '%s' for %s to extra services %s",
+            option,
+            mailClass,
+            codes,
+        )
+        return codes
 
     
 
@@ -183,7 +191,7 @@ class USPSService:
         from_zip_code, from_zip_code_plus = parse_zipcode(shipper_address.zip_code)
         to_first_name, to_last_name = parse_name(recipient_address.contact_name)
         to_zip_code, to_zip_code_plus = parse_zipcode(recipient_address.zip_code)
-        extra_services = get_usps_signature_code(signature_option, serviceType)
+        extra_services = self.get_usps_signature_code(signature_option, serviceType)
         package = packages[0]
         if ship_date is None:
             ship_date = datetime.now().strftime("%Y-%m-%d")

--- a/tests/test_usps_service.py
+++ b/tests/test_usps_service.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+import os
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("DATABASE_URL", "postgresql://localhost/test")
+os.environ.setdefault("JWT_SECRET", "test-secret")
+os.environ.setdefault("SMTP_PASSWORD", "smtp-secret")
+
+from app.external.usps import USPSService
+
+
+@pytest.mark.parametrize(
+    "mail_class, option, expected_codes",
+    [
+        ("PRIORITY_MAIL_EXPRESS", "carrier_default", []),
+        ("PRIORITY_MAIL_EXPRESS", "none", [920]),
+        ("PRIORITY_MAIL_EXPRESS", "direct", [981]),
+        ("PRIORITY_MAIL_EXPRESS", "indirect", [986]),
+        ("PRIORITY_MAIL_EXPRESS", "adult", [922]),
+        ("PRIORITY_MAIL", "carrier_default", []),
+        ("PRIORITY_MAIL", "none", [920]),
+        ("PRIORITY_MAIL", "direct", [921]),
+        ("PRIORITY_MAIL", "indirect", [924]),
+        ("PRIORITY_MAIL", "adult", [922]),
+        ("USPS_GROUND_ADVANTAGE", "carrier_default", []),
+        ("USPS_GROUND_ADVANTAGE", "none", [920]),
+        ("USPS_GROUND_ADVANTAGE", "direct", [921]),
+        ("USPS_GROUND_ADVANTAGE", "indirect", [921]),
+        ("USPS_GROUND_ADVANTAGE", "adult", [922]),
+    ],
+)
+def test_get_usps_signature_code_expected_results(mail_class, option, expected_codes):
+    service = USPSService()
+
+    result = service.get_usps_signature_code(option, mail_class)
+
+    assert result == expected_codes
+
+
+def test_get_usps_signature_code_invalid_combination():
+    service = USPSService()
+
+    with pytest.raises(ValueError):
+        service.get_usps_signature_code("unknown", "PRIORITY_MAIL")
+
+    with pytest.raises(ValueError):
+        service.get_usps_signature_code("direct", "UNKNOWN_SERVICE")


### PR DESCRIPTION
## Summary
- convert `USPSService.get_usps_signature_code` into an instance helper that reads the service signature option mapping and logs the resolved codes
- update label purchase flow to call the instance method
- add pytest coverage to validate every configured signature option resolves to the expected USPS extra-service codes

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cdbb98e088832e86bbf4bcd8ef06c4