### PR TITLE
Update USPS label purchase flow

### DIFF
--- a/app/utils/mist.py
+++ b/app/utils/mist.py
@@ -1,5 +1,5 @@
 import re
-def parse_name(self, full_name: str) -> tuple[str, str]:
+def parse_name(full_name: str) -> tuple[str, str]:
     """
     Parses a full name string into a first name and last name.
     

--- a/tests/test_usps_service.py
+++ b/tests/test_usps_service.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import os
+import logging
 
 import pytest
 
@@ -11,8 +12,64 @@ if str(ROOT) not in sys.path:
 os.environ.setdefault("DATABASE_URL", "postgresql://localhost/test")
 os.environ.setdefault("JWT_SECRET", "test-secret")
 os.environ.setdefault("SMTP_PASSWORD", "smtp-secret")
+os.environ.setdefault("DEFAULT_CONTACT_PHONE", "5125550100")
 
 from app.external.usps import USPSService
+from app.schemas.label import AddressSchema
+from app.core.exceptions import (
+    ExternalServiceClientError,
+    ExternalServiceServerError,
+)
+
+
+@pytest.fixture
+def shipper_address() -> AddressSchema:
+    return AddressSchema(
+        contact_name="Sender One",
+        company_name="Sender LLC",
+        street_line1="123 Sender St",
+        street_line2="Suite 100",
+        city="Austin",
+        state="TX",
+        postal_code="73301",
+        country_code="US",
+        phone="5125550101",
+        email="shipper@example.com",
+    )
+
+
+@pytest.fixture
+def recipient_address() -> AddressSchema:
+    return AddressSchema(
+        contact_name="Receiver Two",
+        company_name="Receiver Corp",
+        street_line1="456 Receiver Ave",
+        street_line2="Apt 2",
+        city="Dallas",
+        state="TX",
+        postal_code="75201",
+        country_code="US",
+        phone="2145550102",
+        email="recipient@example.com",
+    )
+
+
+@pytest.fixture
+def usps_packages() -> list[dict]:
+    return [
+        {
+            "packageId": "PKG1",
+            "weight": {"value": 32, "unit": "OZ"},
+            "dimensions": {"length": 10, "width": 8, "height": 4, "unit": "IN"},
+            "insuredValue": {"amount": "20.00", "currencyCode": "USD"},
+            "references": [{"name": "ORDER", "value": "ORDER-123"}],
+        }
+    ]
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
 
 
 @pytest.mark.parametrize(
@@ -51,3 +108,121 @@ def test_get_usps_signature_code_invalid_combination():
 
     with pytest.raises(ValueError):
         service.get_usps_signature_code("direct", "UNKNOWN_SERVICE")
+
+
+@pytest.mark.anyio
+async def test_buy_label_success(monkeypatch, caplog, shipper_address, recipient_address, usps_packages):
+    service = USPSService()
+
+    sample_response = {
+        "labelId": "LBL123456",
+        "trackingNumber": "9400100000000000000000",
+        "labelDownload": {
+            "url": "https://example.com/label.pdf",
+            "contentType": "application/pdf",
+        },
+        "postage": {"amount": "8.95", "currencyCode": "USD"},
+        "fees": [
+            {
+                "description": "Signature Confirmation",
+                "amount": {"value": "2.10", "currencyCode": "USD"},
+            }
+        ],
+    }
+
+    recorded: dict[str, object] = {}
+
+    async def fake_make_request(method: str, endpoint: str, data: dict | None = None):
+        recorded["method"] = method
+        recorded["endpoint"] = endpoint
+        recorded["data"] = data
+        return sample_response
+
+    monkeypatch.setattr(service, "_make_request", fake_make_request)
+
+    caplog.set_level(logging.INFO)
+
+    result = await service.buy_label(
+        shipper_address=shipper_address,
+        recipient_address=recipient_address,
+        serviceType="USPS_GROUND_ADVANTAGE",
+        packages=usps_packages,
+        signature_option="none",
+        ship_date="2024-09-19",
+    )
+
+    assert recorded["method"] == "POST"
+    assert recorded["endpoint"] == "/labels/v3/label"
+
+    payload = recorded["data"]
+    assert isinstance(payload, dict)
+    assert payload["mailClass"] == "USPS_GROUND_ADVANTAGE"
+    assert payload["extraServices"] == [920]
+    assert payload["packageDescription"]["weight"] == 32
+    assert payload["packageDescription"]["weightUOM"] == "OZ"
+    assert {"name": "ORDER", "value": "ORDER-123"} in payload["references"]
+    assert any(ref["name"] == "SERVICE" for ref in payload["references"])
+
+    labels = result["labels"]
+    assert isinstance(labels, list)
+    assert len(labels) == 1
+    label = labels[0]
+    assert label["trackingNumber"] == "9400100000000000000000"
+    assert label["labelUrl"] == "https://example.com/label.pdf"
+    assert label["charges"]["total"] == "11.05"
+    assert label["price"] == "11.05"
+    assert label["packageDocuments"][0]["url"] == "https://example.com/label.pdf"
+
+    assert any("USPS label created successfully" in record.message for record in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_buy_label_raises_client_error(monkeypatch, shipper_address, recipient_address, usps_packages):
+    service = USPSService()
+
+    async def fake_make_request(method: str, endpoint: str, data: dict | None = None):
+        return {
+            "errors": [
+                {"code": "API-400", "message": "Bad request", "status": 400},
+            ]
+        }
+
+    monkeypatch.setattr(service, "_make_request", fake_make_request)
+
+    with pytest.raises(ExternalServiceClientError) as excinfo:
+        await service.buy_label(
+            shipper_address=shipper_address,
+            recipient_address=recipient_address,
+            serviceType="USPS_GROUND_ADVANTAGE",
+            packages=usps_packages,
+            signature_option="none",
+            ship_date="2024-09-19",
+        )
+
+    assert "Bad request" in str(excinfo.value)
+
+
+@pytest.mark.anyio
+async def test_buy_label_raises_server_error(monkeypatch, shipper_address, recipient_address, usps_packages):
+    service = USPSService()
+
+    async def fake_make_request(method: str, endpoint: str, data: dict | None = None):
+        return {
+            "errors": [
+                {"code": "SVC-500", "message": "System failure", "status": 500},
+            ]
+        }
+
+    monkeypatch.setattr(service, "_make_request", fake_make_request)
+
+    with pytest.raises(ExternalServiceServerError) as excinfo:
+        await service.buy_label(
+            shipper_address=shipper_address,
+            recipient_address=recipient_address,
+            serviceType="USPS_GROUND_ADVANTAGE",
+            packages=usps_packages,
+            signature_option="none",
+            ship_date="2024-09-19",
+        )
+
+    assert "System failure" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- update the USPS label purchase call to hit the labels v3 endpoint, normalize label data, and surface API errors clearly
- add helpers for formatting USPS payloads, parsing label charges, and ensuring references and documents are preserved
- expand USPS service tests with async label purchase scenarios and fix the shared name parser signature

## Testing
- pytest tests/test_usps_service.py

------
https://chatgpt.com/codex/tasks/task_e_68cdbcf30c2c832eb19a7f5b7a08b11e